### PR TITLE
Parallelize RSS builds

### DIFF
--- a/lib/lifer/builder/rss.rb
+++ b/lib/lifer/builder/rss.rb
@@ -27,7 +27,7 @@ class Lifer::Builder::RSS < Lifer::Builder
   #
   # @return [void]
   def execute
-    collections_with_feeds.each do |collection|
+    Lifer::Utilities.parallelized collections_with_feeds do |collection|
       next unless (filename = output_filename(collection))
 
       FileUtils.mkdir_p File.dirname(filename)


### PR DESCRIPTION
In commit 6317818, we were able to parallelize HTML builds. We can follow a similar pattern to parallelize RSS feed building.

The difference being that we can parallelize per collection here, because we'd only be creating one feed per collection with zero overlap.
