### PR TITLE
Allow users to disable parallelism

### DIFF
--- a/lib/lifer.rb
+++ b/lib/lifer.rb
@@ -96,6 +96,16 @@ module Lifer
     #   project would be built to.
     def output_directory = brain.output_directory
 
+    # Returns false if the Lifer project will be built with parallelism. This
+    # should return false almost always--unless you've explicitly set the
+    # `LIFER_UNPARALLELIZED` environment variable before running the program.
+    #
+    # This method is used internally by Lifer to determine whether features that
+    # would normally run in parallel should *not* run in parallel for some reason.
+    #
+    # @return [boolean] Returns whether parallelism is disabled.
+    def parallelism_disabled? = ENV["LIFER_UNPARALLELIZED"].is_a?(String)
+
     # Register new settings so that they are "safe" and can be read from a Lifer
     # configuration file. Unregistered settings are ignored.
     #

--- a/lib/lifer/utilities.rb
+++ b/lib/lifer/utilities.rb
@@ -76,7 +76,10 @@ module Lifer::Utilities
     # @raise [Exception] Any exception thrown by a child process.
     # @return [Array] The mapped results of the operation.
     def parallelized(collection, &block)
-      results = Parallel.map(collection) do |collection_item|
+      options = {}
+      options[:in_threads] = 0 if Lifer.parallelism_disabled?
+
+      results = Parallel.map(collection, **options) do |collection_item|
         begin
           yield collection_item
         rescue => error

--- a/spec/lifer/utilities_spec.rb
+++ b/spec/lifer/utilities_spec.rb
@@ -77,18 +77,45 @@ RSpec.describe Lifer::Utilities do
       end
     }
 
-    context "when no errors should be raised" do
-      let(:collection) { [1, 2, 3] }
+    context "by default (parallelism enabled)" do
+      context "when no errors should be raised" do
+        let(:collection) { [1, 2, 3] }
 
-      it { is_expected.to eq [2, 4, 6] }
+        it { is_expected.to eq [2, 4, 6] }
+      end
+
+      context "when an error should be raised" do
+        let(:collection) { [1, 2, nil, 3] }
+
+        it "bubbles up the exception" do
+          expect { subject }.to raise_error NoMethodError,
+            "undefined method `*' for nil"
+        end
+      end
     end
 
-    context "when an error should be raised" do
-      let(:collection) { [1, 2, nil, 3] }
+    context "when parallelism is disabled" do
+      around do |example|
+        original_value = ENV["LIFER_UNPARALLELIZED"]
+        ENV["LIFER_UNPARALLELIZED"] = "truthy"
+        example.run
+      ensure
+        ENV["LIFER_UNPARALLELIZED"] = original_value
+      end
 
-      it "bubbles up the exception" do
-        expect { subject }.to raise_error NoMethodError,
-          "undefined method `*' for nil"
+      context "when no errors should be raised" do
+        let(:collection) { [1, 2, 3] }
+
+        it { is_expected.to eq [2, 4, 6] }
+      end
+
+      context "when an error should be raised" do
+        let(:collection) { [1, 2, nil, 3] }
+
+        it "bubbles up the exception" do
+          expect { subject }.to raise_error NoMethodError,
+            "undefined method `*' for nil"
+        end
       end
     end
   end

--- a/spec/lifer_spec.rb
+++ b/spec/lifer_spec.rb
@@ -136,6 +136,25 @@ RSpec.describe Lifer do
     end
   end
 
+  describe ".parallelism_disabled?" do
+    subject { described_class.parallelism_disabled? }
+
+    context "by default" do
+      it { is_expected.to eq false }
+    end
+
+    context "when parallelism has been disabled by the user" do
+      it "returns true" do
+        original_value = ENV["LIFER_UNPARALLELIZED"]
+        ENV["LIFER_UNPARALLELIZED"] = "truthy"
+
+        expect(subject).to eq true
+      ensure
+        ENV["LIFER_UNPARALLELIZED"] = original_value
+      end
+    end
+  end
+
   describe ".register_settings" do
     subject { described_class.register_settings *settings }
 


### PR DESCRIPTION
This is nice if someone is trying to test something using breakpoints and they stuck in a process that gets split across many threads. Just get rid of the threads!
