### PR TITLE
Allow non-ASCII characters in entry summaries

### DIFF
--- a/spec/lifer/entry/markdown_spec.rb
+++ b/spec/lifer/entry/markdown_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Lifer::Entry::Markdown do
       it { is_expected.to eq "Short body text." }
     end
 
-    context "when the summary is present and the body is long" do
+    context "when the summary is present and the body is long and contains elements" do
       let(:file) {
         temp_file "long.md", <<~MARKDOWN
-          In the realm where dreams dance upon ethereal melodies and
+          In the "realm" where dreams dance upon [ethereal](#) melodies and
           time surrenders to whispers of serenity, there lies a tapestry
           of old that looks like total shit.
         MARKDOWN
@@ -37,8 +37,9 @@ RSpec.describe Lifer::Entry::Markdown do
 
       it {
         is_expected
- 	        .to eq "In the realm where dreams dance upon ethereal melodies and " \
-	          "time surrenders to whispers of serenity, there lies a tapestry..."
+          .to eq <<~TEXT.strip
+            In the “realm” where dreams dance upon ethereal melodies and time surrenders to whispers of serenity, there lies a tapest...
+         TEXT
       }
     end
 


### PR DESCRIPTION
This was a bug. When I originally implemented summaries as first paragraphs, I didn't realize that using the Kramdown representation of the document would result in special characters being transformed badly:

    In the ldquorealmrdquo where dreams dance

This change ensures that we don't end up with trash like that, or other HTML trash.

The summary is meant to be ideal for things like `<meta>` description tags, which should only contain plain text.
