### PR TITLE
Differentiate permalinks from output filenames

### DIFF
--- a/lib/lifer/entry.rb
+++ b/lib/lifer/entry.rb
@@ -194,9 +194,10 @@ module Lifer
           cached_permalink_variable,
           File.join(
             host,
-            Lifer::URIStrategy.find(collection.setting :uri_strategy)
+            Lifer::URIStrategy
+              .find(collection.setting :uri_strategy)
               .new(root: Lifer.root)
-              .output_file(self)
+              .permalink(self)
           )
         )
     end

--- a/lib/lifer/uri_strategy.rb
+++ b/lib/lifer/uri_strategy.rb
@@ -39,6 +39,24 @@ class Lifer::URIStrategy
     raise NotImplementedError, I18n.t("shared.not_implemented_method")
   end
 
+  # This method should sometimes return the path to the file in the format
+  # specified by the current URI strategy. Of course, this depends on what the URI
+  # stategy is. For "pretty" strategies, the permalink may differ from the output
+  # filename. For example, the output file may point to
+  #
+  #    entry-name/index.html
+  #
+  # While the permalink like points to:
+  #
+  #    entry-name
+  #
+  # @raise [NotImplementedError] This method must be implemented on each
+  #   subclass.
+  # @return [String] The permalink to the built output file.
+  def permalink(entry)
+    raise NotImplementedError, I18n.t("shared.not_implemented_error")
+  end
+
   private
 
   def file_extension(entry) = entry.class.output_extension

--- a/lib/lifer/uri_strategy/pretty.rb
+++ b/lib/lifer/uri_strategy/pretty.rb
@@ -14,8 +14,12 @@ class Lifer::URIStrategy::Pretty < Lifer::URIStrategy
     basename = File.basename entry.file,
       Lifer::Utilities.file_extension(entry.file)
 
-    Pathname entry.file.to_s
+    entry.file.to_s
       .gsub(/#{root}[\/]{0,1}/, "")
-      .gsub(/#{basename}(\..+)/, "#{basename}/index.#{file_extension(entry)}")
+      .gsub(/#{basename}(\..+)/, "#{basename}#{pretty_part entry}")
   end
+
+  private
+
+  def pretty_part(entry) = "/index.#{file_extension(entry)}"
 end

--- a/lib/lifer/uri_strategy/pretty.rb
+++ b/lib/lifer/uri_strategy/pretty.rb
@@ -19,6 +19,9 @@ class Lifer::URIStrategy::Pretty < Lifer::URIStrategy
       .gsub(/#{basename}(\..+)/, "#{basename}#{pretty_part entry}")
   end
 
+  # @see Lifer::UriStrategy#permalink
+  def permalink(entry) = output_file(entry).gsub pretty_part(entry), ""
+
   private
 
   def pretty_part(entry) = "/index.#{file_extension(entry)}"

--- a/lib/lifer/uri_strategy/pretty_root.rb
+++ b/lib/lifer/uri_strategy/pretty_root.rb
@@ -18,6 +18,15 @@ class Lifer::URIStrategy
       end
     end
 
+    # @see Lifer::UriStrategy#permalink
+    def permalink(entry)
+      if basename(entry) == "index"
+        "/"
+      else
+        output_file(entry).gsub pretty_part(entry), ""
+      end
+    end
+
     private
 
     def basename(entry)

--- a/lib/lifer/uri_strategy/pretty_root.rb
+++ b/lib/lifer/uri_strategy/pretty_root.rb
@@ -11,14 +11,19 @@ class Lifer::URIStrategy
 
     # @see Lifer::URIStrategy#output_file
     def output_file(entry)
-      basename = File.basename entry.file,
-        Lifer::Utilities.file_extension(entry.file)
-
-      if basename == "index"
-        Pathname "index.html"
+      if basename(entry) == "index"
+        "index.html"
       else
-        Pathname "#{basename}/index.#{file_extension(entry)}"
+        "#{basename entry}#{pretty_part entry}"
       end
     end
+
+    private
+
+    def basename(entry)
+      File.basename entry.file, Lifer::Utilities.file_extension(entry.file)
+    end
+
+    def pretty_part(entry) = "/index.#{file_extension(entry)}"
   end
 end

--- a/lib/lifer/uri_strategy/pretty_yyyy_mm_dd.rb
+++ b/lib/lifer/uri_strategy/pretty_yyyy_mm_dd.rb
@@ -24,9 +24,13 @@
     basename = File.basename entry.file,
       Lifer::Utilities.file_extension(entry.file)
 
-    Pathname entry.file.to_s
+    entry.file.to_s
       .gsub(/#{root}[\/]{0,1}/, "")
-      .gsub(/#{basename}(\..+)/, "#{basename}/index.#{file_extension(entry)}")
+      .gsub(/#{basename}(\..+)/, "#{basename}#{pretty_part entry}")
       .gsub(DATE_REGEXP, "")
   end
+
+  private
+
+  def pretty_part(entry) = "/index.#{file_extension(entry)}"
 end

--- a/lib/lifer/uri_strategy/pretty_yyyy_mm_dd.rb
+++ b/lib/lifer/uri_strategy/pretty_yyyy_mm_dd.rb
@@ -30,6 +30,9 @@
       .gsub(DATE_REGEXP, "")
   end
 
+  # @see Lifer::UriStrategy#permalink
+  def permalink(entry) = output_file(entry).gsub pretty_part(entry), ""
+
   private
 
   def pretty_part(entry) = "/index.#{file_extension(entry)}"

--- a/lib/lifer/uri_strategy/root.rb
+++ b/lib/lifer/uri_strategy/root.rb
@@ -11,7 +11,7 @@ class Lifer::URIStrategy
       basename = File.basename entry.file,
         Lifer::Utilities.file_extension(entry.file)
 
-      Pathname "#{basename}.#{file_extension(entry)}"
+      "#{basename}.#{file_extension(entry)}"
     end
   end
 end

--- a/lib/lifer/uri_strategy/root.rb
+++ b/lib/lifer/uri_strategy/root.rb
@@ -13,5 +13,8 @@ class Lifer::URIStrategy
 
       "#{basename}.#{file_extension(entry)}"
     end
+
+    # @see Lifer::UriStrategy#permalink
+    def permalink(entry) = output_file(entry)
   end
 end

--- a/lib/lifer/uri_strategy/simple.rb
+++ b/lib/lifer/uri_strategy/simple.rb
@@ -14,4 +14,7 @@ class Lifer::URIStrategy::Simple < Lifer::URIStrategy
       .gsub(/#{root}[\/]{0,1}/, "")
       .gsub(/#{basename}(\..+)/, "#{basename}.#{file_extension(entry)}")
   end
+
+  # @see Lifer::UriStrategy#permalink
+  def permalink(entry) = output_file(entry)
 end

--- a/lib/lifer/uri_strategy/simple.rb
+++ b/lib/lifer/uri_strategy/simple.rb
@@ -10,7 +10,7 @@ class Lifer::URIStrategy::Simple < Lifer::URIStrategy
     basename = File.basename entry.file,
       Lifer::Utilities.file_extension(entry.file)
 
-    Pathname entry.file.to_s
+    entry.file.to_s
       .gsub(/#{root}[\/]{0,1}/, "")
       .gsub(/#{basename}(\..+)/, "#{basename}.#{file_extension(entry)}")
   end

--- a/spec/lifer/builder/html/from_erb_spec.rb
+++ b/spec/lifer/builder/html/from_erb_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe Lifer::Builder::HTML::FromERB do
              Another Another Entry, Another Entry
              <h2>This project's settings</h2>
              {:uri_strategy=>"simple", :subdirectory_one=>{:uri_strategy=>"pretty"}}
+             <h2>Entry permalinks do not include index.html because of the pretty URI strategy</h2>
+             https://example.com/entry-with-variables
            </body>
          </html>
        RESULT

--- a/spec/lifer/builder/html/from_liquid_spec.rb
+++ b/spec/lifer/builder/html/from_liquid_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe Lifer::Builder::HTML::FromLiquid do
       let(:config) {
        <<~CONFIG
           layout_file: ../_layouts/layout.html.liquid
-          uri_strategy: pretty
+          uri_strategy: simple
 
           subdirectory_one:
-            uri_strategy: simple
+            uri_strategy: pretty
 
           test_setting:
             - number: 123
@@ -95,10 +95,12 @@ RSpec.describe Lifer::Builder::HTML::FromLiquid do
           <h2>Entries for tag1</h2>
           Entry Title 1, Entry Title 2
           <h2>This project's settings</h2>
-          all settings: {"layout_file":"../_layouts/layout.html.liquid","uri_strategy":"pretty","subdirectory_one":{"uri_strategy":"simple"},"test_setting":[{"number":123,"description":"To tests arrays of objects."}]}
+          all settings: {"layout_file":"../_layouts/layout.html.liquid","uri_strategy":"simple","subdirectory_one":{"uri_strategy":"pretty"},"test_setting":[{"number":123,"description":"To tests arrays of objects."}]}
           root layout file: ../_layouts/layout.html.liquid
-          root URI strategy: pretty
-          subdirectory one URI strategy: simple
+          root URI strategy: simple
+          subdirectory one URI strategy: pretty
+          <h2>Permalinks do not include index.html because of the pretty URI strategy</h2>
+          https://example.com/entry
        RESULT
       end
     end

--- a/spec/lifer/uri_strategy/pretty_root_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_root_spec.rb
@@ -53,4 +53,40 @@ RSpec.describe Lifer::URIStrategy::PrettyRoot do
       end
     end
   end
+
+  describe "#permalink" do
+    subject { uri_strategy.permalink entry }
+
+    let(:entry) { Lifer::Entry::Markdown.new file:, collection: }
+
+    context "when the entry is an index file" do
+      let(:collection) {
+        Lifer::Collection.generate name: :root, directory: File.dirname(file)
+      }
+      let(:file) { Dir.glob("#{root}/**/index.html").first }
+
+      it { is_expected.to eq "/" }
+    end
+
+    context "when in the root collection" do
+      let(:collection) {
+        Lifer::Collection.generate name: :root, directory: File.dirname(file)
+      }
+      let(:file) { Dir.glob("#{root}/**/entry.md").first }
+
+      it { is_expected.to eq "entry" }
+    end
+
+    context "when not in the root collection" do
+      let(:collection) {
+        Lifer::Collection.generate name: :subdirectory_one,
+          directory: File.dirname(file)
+      }
+      let(:file) {
+        Dir.glob("#{root}/**/subdir/sub.md").first
+      }
+
+      it { is_expected.to eq "sub" }
+    end
+  end
 end

--- a/spec/lifer/uri_strategy/pretty_root_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_root_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Lifer::URIStrategy::PrettyRoot do
       let(:file) { Dir.glob("#{root}/**/index.html").first }
 
       it "takes an `index.html` URI instead of `index/index.html`" do
-        expect(subject).to eq Pathname("index.html")
+        expect(subject).to eq "index.html"
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Lifer::URIStrategy::PrettyRoot do
       }
       let(:file) { Dir.glob("#{root}/**/entry.md").first }
 
-      it { is_expected.to eq Pathname("entry/index.html") }
+      it { is_expected.to eq "entry/index.html" }
     end
 
     context "when not in the root collection" do
@@ -49,7 +49,7 @@ RSpec.describe Lifer::URIStrategy::PrettyRoot do
       }
 
       it "still returns an output at the root" do
-        expect(subject).to eq Pathname("sub/index.html")
+        expect(subject).to eq "sub/index.html"
       end
     end
   end

--- a/spec/lifer/uri_strategy/pretty_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_spec.rb
@@ -36,4 +36,26 @@ RSpec.describe Lifer::URIStrategy::Pretty do
       end
     end
   end
+
+  describe "#permalink" do
+    subject { uri_strategy.permalink entry }
+
+    let(:collection) {
+      Lifer::Collection.generate name: "Collection",
+        directory: File.dirname(file)
+    }
+    let(:entry) { Lifer::Entry::Markdown.new file:, collection: }
+
+    context "in the root directory" do
+      let(:file) { Dir.glob("#{root}/**/entry.md").first }
+
+      it { is_expected.to eq "entry" }
+    end
+
+    context "in a subdirectory" do
+      let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
+
+      it { is_expected.to eq "subdir/subsubdir/sub_entry" }
+    end
+  end
 end

--- a/spec/lifer/uri_strategy/pretty_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Lifer::URIStrategy::Pretty do
     context "in the root directory" do
       let(:file) { Dir.glob("#{root}/**/entry.md").first }
 
-      it { is_expected.to eq Pathname("entry/index.html") }
+      it { is_expected.to eq "entry/index.html" }
     end
 
     context "in a subdirectory" do
       let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
 
       it "returns the output file path" do
-        expect(subject).to eq Pathname("subdir/subsubdir/sub_entry/index.html")
+        expect(subject).to eq "subdir/subsubdir/sub_entry/index.html"
       end
     end
   end

--- a/spec/lifer/uri_strategy/pretty_yyyy_mm_dd_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_yyyy_mm_dd_spec.rb
@@ -47,4 +47,34 @@ RSpec.describe Lifer::URIStrategy::PrettyYYYYMMDD do
       end
     end
   end
+
+  describe "#permalink" do
+    subject { uri_strategy.permalink entry }
+
+    let(:collection) {
+      Lifer::Collection.generate name: "Collection",
+        directory: File.dirname(file)
+    }
+    let(:entry) {
+      Lifer::Entry::Markdown.new file: file, collection: collection
+    }
+
+    context "in the root directory" do
+      let(:file) { Dir.glob("#{root}/**/entry.md").first }
+
+      it { is_expected.to eq "entry" }
+    end
+
+    context "in a subdirectory" do
+      let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
+
+      it { is_expected.to eq "subdir/subsubdir/sub_entry" }
+    end
+
+    context "when the filename includes the date" do
+      let(:file) { Dir.glob("#{root}/**/2012-03-25_with_date.md").first }
+
+      it { is_expected.to eq "with_date" }
+    end
+  end
 end

--- a/spec/lifer/uri_strategy/pretty_yyyy_mm_dd_spec.rb
+++ b/spec/lifer/uri_strategy/pretty_yyyy_mm_dd_spec.rb
@@ -28,15 +28,14 @@ RSpec.describe Lifer::URIStrategy::PrettyYYYYMMDD do
     context "in the root directory" do
       let(:file) { Dir.glob("#{root}/**/entry.md").first }
 
-      it { is_expected.to eq Pathname("entry/index.html") }
+      it { is_expected.to eq "entry/index.html" }
     end
 
     context "in a subdirectory" do
       let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
 
       it "returns the output file path" do
-        expect(subject)
-          .to eq Pathname("subdir/subsubdir/sub_entry/index.html")
+        expect(subject).to eq "subdir/subsubdir/sub_entry/index.html"
       end
     end
 
@@ -44,7 +43,7 @@ RSpec.describe Lifer::URIStrategy::PrettyYYYYMMDD do
       let(:file) { Dir.glob("#{root}/**/2012-03-25_with_date.md").first }
 
       it "returns the output file path without the date" do
-        expect(subject).to eq Pathname("with_date/index.html")
+        expect(subject).to eq "with_date/index.html"
       end
     end
   end

--- a/spec/lifer/uri_strategy/root_spec.rb
+++ b/spec/lifer/uri_strategy/root_spec.rb
@@ -36,4 +36,31 @@ RSpec.describe Lifer::URIStrategy::Root do
       end
     end
   end
+
+  describe "#permalink" do
+    subject { uri_strategy.permalink entry }
+
+    let(:entry) { Lifer::Entry::Markdown.new file:, collection: }
+
+    context "when in the root collection" do
+      let(:collection) {
+        Lifer::Collection.generate name: :root, directory: File.dirname(file)
+      }
+      let(:file) { Dir.glob("#{root}/**/entry.md").first }
+
+      it { is_expected.to eq "entry.html" }
+   end
+
+    context "when not in the root collection" do
+      let(:collection) {
+        Lifer::Collection.generate name: :subdirectory_one,
+          directory: File.dirname(file)
+      }
+      let(:file) { Dir.glob("#{root}/**/subdir/sub.md").first }
+
+      it "still returns a permalink at the root" do
+        expect(subject).to eq "sub.html"
+      end
+    end
+  end
 end

--- a/spec/lifer/uri_strategy/root_spec.rb
+++ b/spec/lifer/uri_strategy/root_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Lifer::URIStrategy::Root do
       }
       let(:file) { Dir.glob("#{root}/**/entry.md").first }
 
-      it { is_expected.to eq Pathname("entry.html") }
+      it { is_expected.to eq "entry.html" }
     end
 
     context "when not in the root collection" do
@@ -32,7 +32,7 @@ RSpec.describe Lifer::URIStrategy::Root do
       let(:file) { Dir.glob("#{root}/**/subdir/sub.md").first }
 
       it "still returns an output at the root" do
-        expect(subject).to eq Pathname("sub.html")
+        expect(subject).to eq "sub.html"
       end
     end
   end

--- a/spec/lifer/uri_strategy/simple_spec.rb
+++ b/spec/lifer/uri_strategy/simple_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Lifer::URIStrategy::Simple do
     context "in the root directory" do
       let(:file) { Dir.glob("#{root}/**/entry.md").first }
 
-      it { is_expected.to eq Pathname("entry.html") }
+      it { is_expected.to eq "entry.html" }
     end
 
     context "in a subdirectory" do
       let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
 
       it "returns the output file path" do
-        expect(subject).to eq Pathname("subdir/subsubdir/sub_entry.html")
+        expect(subject).to eq "subdir/subsubdir/sub_entry.html"
       end
     end
   end

--- a/spec/lifer/uri_strategy/simple_spec.rb
+++ b/spec/lifer/uri_strategy/simple_spec.rb
@@ -36,4 +36,26 @@ RSpec.describe Lifer::URIStrategy::Simple do
       end
     end
   end
+
+  describe "#permalink" do
+    subject { uri_strategy.permalink entry }
+
+    let(:collection) {
+      Lifer::Collection.generate name: "Collection",
+        directory: File.dirname(file)
+    }
+    let(:entry) { Lifer::Entry::Markdown.new file:, collection: }
+
+    context "in the root directory" do
+      let(:file) { Dir.glob("#{root}/**/entry.md").first }
+
+      it { is_expected.to eq "entry.html" }
+    end
+
+    context "in a subdirectory" do
+      let(:file) { Dir.glob("#{root}/**/sub_entry.md").first }
+
+      it { is_expected.to eq "subdir/subsubdir/sub_entry.html" }
+    end
+  end
 end

--- a/spec/support/entries/layout_variables_test_entry.html.erb
+++ b/spec/support/entries/layout_variables_test_entry.html.erb
@@ -21,3 +21,6 @@
 <h2>This project's settings</h2>
 
 <%= settings %>
+
+<h2>Entry permalinks do not include index.html because of the pretty URI strategy</h2>
+<%= entry.permalink %>

--- a/spec/support/entries/layout_variables_test_entry.html.liquid
+++ b/spec/support/entries/layout_variables_test_entry.html.liquid
@@ -48,3 +48,6 @@ all settings: {{ settings }}
 root layout file: {{ settings.layout_file }}
 root URI strategy: {{ settings.uri_strategy }}
 subdirectory one URI strategy: {{ settings.subdirectory_one.uri_strategy }}
+
+<h2>Permalinks do not include index.html because of the pretty URI strategy</h2>
+{{ entry.permalink }}


### PR DESCRIPTION
URI strategies have been great so far, but I realized that sometimes the output filename on disk should differ from the user-facing permalink. Specifically, when every the URI strategy is "pretty".

Example output filename:

    /my/filename/index.html

Expected permalink for this file using a pretty URI strategy:

    /my/filename
    
To resolve this, URI strategies now provide methods for both the output filename and the permalink to each entry.