### PR TITLE
Improve ERB rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Next
 
+This release adds a new `#render` method that can be used in any ERB files being
+built into HTML documents. It matches the functionality of Liquid's builtiin
+`render` functionality. So:
+
+    {% render "my_partial.html.liquid" with local_variable: "some-value" %}
+
+is equivalent to:
+
+    <%= render "my_partial.html.erb", local_variable: "some-value" %>
+
 ## v0.11.0
 
 This release adds new functionality to our URI strategies, adding
@@ -35,7 +45,6 @@ trash.
 
 The summary is meant to be ideal for things like `<meta>` description tags,
 which should only contain plain text.
-
 
 ## v0.10.0
 

--- a/lib/lifer/builder/html.rb
+++ b/lib/lifer/builder/html.rb
@@ -7,9 +7,22 @@ require "fileutils"
 # ERB[1] or Liquid[2] template files. The layout file yields entry contents
 # via a `content` call that is parsed by ERB or Liquid.
 #
-# Layout files can also include other contextual information about the current
-# Lifer project to provide "normal website features" like navigation links,
-# indexes, and so on. Context is provided via:
+# It is normal to have templates that render other templates. So normal, in
+# fact, that Liquid provides a built-in `render` function that allows us to render
+# partials from other Liquid files:
+#
+#     {% render "path/to/my/partial.html.liquid" with local_variable: "value" %}
+#
+# And we've ensured a similar `render` function exists for our ERB HTML builder:
+#
+#     <%= render "path/to/my/partial.html.erb", local_variable: "value" %>
+#
+# The entry being built will include contextual data about the current project,
+# so that the user can build out normal website features like navigation links,
+# indexes, and so on. Note that with the current Liquid implementation, you may
+# need to explicitly pass context from layouts to the partials that require it via
+# `with`. Meanwhile, the ERB implementation provides a bunch of context globally.
+# Context includes:
 #
 #  - `my_collection_name`: Or, any collection by name.
 #

--- a/lib/lifer/builder/html/from_any.rb
+++ b/lib/lifer/builder/html/from_any.rb
@@ -10,7 +10,7 @@ class Lifer::Builder
         # @param entry [Lifer::Entry] The entry to be rendered.
         # @return [String] The rendered entry.
         def build(entry:)
-          new(entry: entry).render
+          new(entry: entry).build
         end
       end
 

--- a/lib/lifer/builder/html/from_erb.rb
+++ b/lib/lifer/builder/html/from_erb.rb
@@ -34,8 +34,15 @@ class Lifer::Builder::HTML
       return document unless (relative_layout_path = frontmatter[:layout])
 
       document_binding = binding.tap { |binding|
+        context.local_variables.each do |variable|
+          next if variable == :content
+
+          binding.local_variable_set variable,
+            context.local_variable_get(variable)
+        end
         binding.local_variable_set :content, document
       }
+
       layout_path = "%s/%s" % [Lifer.root, relative_layout_path]
       ERB.new(File.read layout_path).result(document_binding)
     end

--- a/lib/lifer/builder/html/from_erb.rb
+++ b/lib/lifer/builder/html/from_erb.rb
@@ -25,10 +25,10 @@ class Lifer::Builder::HTML
   #
   class FromERB < FromAny
     # Reads the entry as ERB, given our renderer context (see the documentation
-    # for `#build_binding_context`) and renders the production-ready entry.
+    # for `#build_binding_context`) and builds the production-ready entry.
     #
-    # @return [String] The rendered entry.
-    def render
+    # @return [String] The resulting HTML entry.
+    def build
       document = ERB.new(layout_file_contents).result context
 
       return document unless (relative_layout_path = frontmatter[:layout])

--- a/lib/lifer/builder/html/from_liquid.rb
+++ b/lib/lifer/builder/html/from_liquid.rb
@@ -28,11 +28,11 @@ class Lifer::Builder::HTML
     require_relative "from_liquid/filters"
     require_relative "from_liquid/liquid_env"
 
-    # Reads the entry as Liquid, given our document context, and renders
-    # an entry.
+    # Reads the Liquid entry, given our document context, and builds an HTML
+    # document.
     #
-    # @return [String] The rendered entry.
-    def render
+    # @return [String] The resulting HTML entry.
+    def build
       document_context = context.merge!(
         "content" => Liquid::Template
           .parse(entry.to_html, **parse_options)

--- a/spec/lifer/builder/html/from_erb_spec.rb
+++ b/spec/lifer/builder/html/from_erb_spec.rb
@@ -18,12 +18,15 @@ RSpec.describe Lifer::Builder::HTML::FromERB do
     )
 
     {
+      "_layouts/partials/header.html.erb" => <<~TEXT,
+        <header id="<%= id %>">
+          This project contains <%= collections.count %> collections
+        </header>
+      TEXT
       "_layouts/root.html.erb" => <<~TEXT,
         <html>
           <body>
-            <header>
-              This project contains <%= collections.count %> collections
-            </header>
+            <%= render "_layouts/partials/header.html.erb", id: "header-123" %>
             <%= content %>
           </body>
         </html>
@@ -119,7 +122,7 @@ RSpec.describe Lifer::Builder::HTML::FromERB do
         expect(subject).to fuzzy_match <<~RESULT
           <html>
             <body>
-              <header>
+              <header id="header-123">
                 This project contains 3 collections
               </header>
               <main><p>Another entry</p>

--- a/spec/lifer/builder/html/from_erb_spec.rb
+++ b/spec/lifer/builder/html/from_erb_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Lifer::Builder::HTML::FromERB do
       "_layouts/root.html.erb" => <<~TEXT,
         <html>
           <body>
+            <header>
+              This project contains <%= collections.count %> collections
+            </header>
             <%= content %>
           </body>
         </html>
@@ -116,6 +119,9 @@ RSpec.describe Lifer::Builder::HTML::FromERB do
         expect(subject).to fuzzy_match <<~RESULT
           <html>
             <body>
+              <header>
+                This project contains 3 collections
+              </header>
               <main><p>Another entry</p>
               </main>
             </body>


### PR DESCRIPTION
This pull request:

- Ensures that when we build HTML documents from ERB, all layouts and partials can have access to context about the current Lifer project (like `settings` and `collections`).
- Ensures that when we build HTML documents from ERB, layouts can call `#render` to render partial layouts.